### PR TITLE
添加饭搭子影视

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <p align="center">
   <a href="https://zhuiju.me"><img src="https://img.shields.io/badge/网站-zhuiju.me-0A66C2?style=flat-square" alt="网站 zhuiju.me" height="24"></a>
   <!-- resource-count:start -->
-<a href="resources/resources.json"><img src="https://img.shields.io/badge/已收录-91_个资源-00A98F?style=flat-square" alt="已收录 91 个资源" height="24"></a>
+<a href="resources/resources.json"><img src="https://img.shields.io/badge/已收录-92_个资源-00A98F?style=flat-square" alt="已收录 92 个资源" height="24"></a>
 <!-- resource-count:end -->
   <a href="https://github.com/laoma2053/awesome-zhuiju-free/actions/workflows/check-availability.yml"><img src="https://img.shields.io/badge/检测时间-2026--08--02-00B4D8?style=flat-square" alt="检测时间 2026-08-02" height="24"></a>
   <a href="https://github.com/laoma2053/awesome-zhuiju-free/stargazers"><img src="https://img.shields.io/github/stars/laoma2053/awesome-zhuiju-free?style=flat-square&label=Stars&color=F7B801" alt="GitHub Stars" height="24"></a>
@@ -64,7 +64,7 @@
 
 <!-- featured-resources:start -->
 <p align="center">
-  <a href="#在线影视"><img src="https://img.shields.io/badge/在线影视-31-0A66C2?style=flat-square" alt="在线影视"></a>
+  <a href="#在线影视"><img src="https://img.shields.io/badge/在线影视-32-0A66C2?style=flat-square" alt="在线影视"></a>
   <a href="#影视app"><img src="https://img.shields.io/badge/影视APP-3-00A98F?style=flat-square" alt="影视APP"></a>
   <a href="#网盘资源搜索"><img src="https://img.shields.io/badge/网盘搜索-4-4285F4?style=flat-square" alt="网盘资源搜索"></a>
   <a href="#磁力-bt"><img src="https://img.shields.io/badge/磁力%26_BT-12-F7B801?style=flat-square" alt="磁力& BT"></a>
@@ -91,6 +91,7 @@
 
 | 资源 | 简介 | 推荐指数 | 状态 | 检测时间 |
 | --- | --- | :---: | :---: | :---: |
+| [饭搭子影视](<https://fdzys.com>) | 最新热门电影电视剧动漫综艺 | 🌟&#8288;🌟&#8288;🌟&#8288;🌟&#8288;🌟 | <!-- availability:fdzys -->🟡&#8288;访问&#8288;受限<!-- /availability:fdzys --> | <!-- availability-date:fdzys -->2026&#8209;08&#8209;08<!-- /availability-date:fdzys --> |
 | [爱看机器人](<https://www1.aikanbot.com>) | 全网热门的电影和电视剧榜单 | 🌟&#8288;🌟&#8288;🌟&#8288;🌟&#8288;🌟 | <!-- availability:aikanbot -->🟢&#8288;可&#8288;访问<!-- /availability:aikanbot --> | <!-- availability-date:aikanbot -->2026&#8209;08&#8209;02<!-- /availability-date:aikanbot --> |
 | [91毒舌](<https://www.duse0.com/>) | 最新Netflix新剧、4K高清（可访问） | 🌟&#8288;🌟&#8288;🌟&#8288;🌟&#8288;🌟 | <!-- availability:duse91 -->🔴&#8288;无法&#8288;访问<!-- /availability:duse91 --> | <!-- availability-date:duse91 -->2026&#8209;08&#8209;02<!-- /availability-date:duse91 --> |
 | [好好看](<https://www.hhkan2.com/>) | 4K高清Netflix新剧（可访问需梯子） | 🌟&#8288;🌟&#8288;🌟&#8288;🌟&#8288;🌟 | <!-- availability:haohaokan -->🔴&#8288;无法&#8288;访问<!-- /availability:haohaokan --> | <!-- availability-date:haohaokan -->2026&#8209;08&#8209;02<!-- /availability-date:haohaokan --> |

--- a/reports/availability.json
+++ b/reports/availability.json
@@ -844,6 +844,17 @@
       "checked_at": "2026-08-02T04:04:47.967Z",
       "attempts": 1,
       "error": null
+    },
+    {
+      "resource_id": "fdzys",
+      "url": "https://fdzys.com",
+      "status": "restricted",
+      "http_status": 429,
+      "final_url": "https://fdzys.com/",
+      "response_ms": null,
+      "checked_at": "2026-08-08T15:37:02.029Z",
+      "attempts": 1,
+      "error": null
     }
   ]
 }

--- a/reports/verifications.json
+++ b/reports/verifications.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-02",
+  "updated_at": "2026-08-08",
   "records": [
     {
       "id": "verify-20260606-initial",
@@ -454,6 +454,21 @@
       },
       "result": "pending_review",
       "notes": "根据用户补充收录磁力帝（https://www.cld123.com，推荐指数 5 星，简介：地址发布页cldi.top）；提交状态不作为本项目状态依据，后续由 GitHub Actions 自动检测可用性，并持续观察版权状态与链接安全性。"
+    },
+    {
+      "id": "verify-20260808-fdzys",
+      "resource_ids": [
+        "fdzys"
+      ],
+      "checked_at": "2026-08-08",
+      "checked_by": "maintainer",
+      "method": "manual",
+      "environment": {
+        "region": "unspecified",
+        "network": "user submitted"
+      },
+      "result": "pending_review",
+      "notes": "根据用户补充收录在线影视资源：饭搭子影视（https://fdzys.com，推荐指数 5 星，简介：最新热门电影电视剧动漫综艺）；提交状态不作为本项目状态依据，后续由 GitHub Actions 自动检测可用性，并持续观察版权状态与站点安全性。"
     }
   ]
 }

--- a/resources/resources.json
+++ b/resources/resources.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema.json",
   "version": 1,
-  "updated_at": "2026-08-02",
+  "updated_at": "2026-08-08",
   "resources": [
     {
       "id": "no-video",
@@ -4181,6 +4181,52 @@
       "source": {
         "submitted_by": "@Function21",
         "added_at": "2026-08-01"
+      },
+      "featured": true
+    },
+    {
+      "id": "fdzys",
+      "name": "饭搭子影视",
+      "url": "https://fdzys.com",
+      "category": "online_video",
+      "summary": "最新热门电影电视剧动漫综艺。",
+      "summary_short": "最新热门电影电视剧动漫综艺",
+      "tags": [
+        "在线影视",
+        "电影",
+        "电视剧",
+        "动漫",
+        "综艺"
+      ],
+      "access": {
+        "requires_login": false,
+        "free_level": "unknown",
+        "regions": [
+          "GLOBAL"
+        ]
+      },
+      "scores": {
+        "more": 5,
+        "speed": 5,
+        "clean": 5,
+        "stable": 5,
+        "ease": 5
+      },
+      "risks": {
+        "copyright": "high",
+        "safety": "medium",
+        "privacy": "unknown",
+        "payment": "unknown"
+      },
+      "verification": {
+        "status": "caution",
+        "last_checked": "2026-08-08",
+        "method": "manual",
+        "notes": "根据用户补充收录在线影视资源：饭搭子影视（https://fdzys.com，推荐指数 5 星，简介：最新热门电影电视剧动漫综艺）；提交状态不作为本项目状态依据，后续由 GitHub Actions 自动检测可用性，并持续观察版权状态与站点安全性。"
+      },
+      "source": {
+        "submitted_by": "maintainer",
+        "added_at": "2026-08-08"
       },
       "featured": true
     }


### PR DESCRIPTION
## 变更内容

- 在“在线影视”分类新增饭搭子影视（https://fdzys.com）
- 简介设为“最新热门电影电视剧动漫综艺”，推荐指数设为 5 星
- 同步 README、验证记录和可用性报告

## 影响

在线影视资源总数由 31 增至 32，仓库资源总数由 91 增至 92。

## 验证

- `node scripts/validate-data.mjs`
- `git diff --check`

首次自动探测返回 HTTP 429，因此当前状态标记为“访问受限”，后续由 GitHub Actions 自动刷新。
